### PR TITLE
Enhance tests and fix error validation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,7 +3,7 @@ import mediaConstraints from './config/media-constraints';
 import './App.css';
 
 class App extends Component {
-  state = { isLoading: true }
+  state = { videoURL: '' }
 
   componentWillMount() {
     navigator.mediaDevices.getUserMedia(mediaConstraints)
@@ -13,15 +13,15 @@ class App extends Component {
 
   onCameraStream = (stream) => {
     const videoURL = URL.createObjectURL(stream);
-    this.setState({ videoURL, isLoading: false });
+    this.setState({ videoURL });
   }
 
-  onCameraError = ({ message: error }) => {
+  onCameraError = (error) => {
     this.setState({ error });
   }
 
   render() {
-    if (this.state.isLoading) return null;
+    if (!this.state.videoURL) return null;
 
     return <video src={this.state.videoURL} muted loop autoPlay />;
   }

--- a/test/__snapshots__/App.test.js.snap
+++ b/test/__snapshots__/App.test.js.snap
@@ -1,3 +1,5 @@
+exports[`App renders null when media access is denied 1`] = `null`;
+
 exports[`App renders null while loading 1`] = `null`;
 
 exports[`App renders the video URL from the stream 1`] = `
@@ -5,5 +7,5 @@ exports[`App renders the video URL from the stream 1`] = `
   autoPlay={true}
   loop={true}
   muted={true}
-  src="http://some_url" />
+  src="http://localhost/e75dbc24-dd2c-4157-bf0e-f0a7773e98c8" />
 `;


### PR DESCRIPTION
- Remove `isLoading` since `videoURL` is enough
- Add `MediaStream` class (and validate the `createObjectURL` against it) to make the stream look like  a real stream
- Add `NavigatorUserMediaError` to fake the user denying the media access
