### PR TITLE
Enh tests adding enzyme and sinon

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,12 @@
   },
   "homepage": "https://github.com/gotik/reccam.io#readme",
   "devDependencies": {
+    "enzyme": "^2.4.1",
+    "enzyme-to-json": "^1.1.1",
+    "react-addons-test-utils": "^15.3.2",
     "react-scripts": "0.4.3",
     "react-test-renderer": "^15.3.2",
+    "sinon": "^1.17.6",
     "uuid": "^2.0.3"
   },
   "dependencies": {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,6 +1,6 @@
-import createObjectURL from '../test/utils/createObjectURL';
-import MediaRecorder from '../test/utils/MediaRecorder';
-import MediaStream from '../test/utils/MediaStream';
+import createObjectURL from '../test/APIs/URL.createObjectURL';
+import MediaRecorder from '../test/APIs/MediaRecorder';
+import MediaStream from '../test/APIs/MediaStream';
 
 global.URL.createObjectURL = createObjectURL;
 global.MediaRecorder = MediaRecorder;

--- a/test/APIs/MediaRecorder.js
+++ b/test/APIs/MediaRecorder.js
@@ -1,5 +1,3 @@
-let MediaRecorderSpy = jest.fn();
-
 class MediaRecorder {
   static isTypeSupported(type) {
     return type === 'video/webm;codecs=vp9' || type === 'video/webm;codecs=vp8';
@@ -10,10 +8,7 @@ class MediaRecorder {
     if (className !== 'MediaStream') {
       throw new TypeError('Failed to construct \'MediaRecorder\': parameter 1 is not of type \'MediaStream\'.');
     }
-
-    MediaRecorderSpy(...arguments);
   }
 }
 
 export default MediaRecorder;
-export { MediaRecorderSpy };

--- a/test/APIs/MediaStream.js
+++ b/test/APIs/MediaStream.js
@@ -1,7 +1,7 @@
 import uuid from 'uuid';
 
 class MediaStream {
-  id = uuid.v4()
+  id = uuid()
   active = true
 }
 

--- a/test/APIs/URL.createObjectURL.js
+++ b/test/APIs/URL.createObjectURL.js
@@ -1,15 +1,12 @@
-let createObjectURLSpy = jest.fn();
-const videoURL = 'http://localhost/e75dbc24-dd2c-4157-bf0e-f0a7773e98c8';
+import uuid from 'uuid';
 
 function createObjectURL(stream) {
   const className = Object.getPrototypeOf(stream).constructor.name;
   if (className === 'Blob' || className === 'MediaStream') {
-    createObjectURLSpy(...arguments);
-    return videoURL;
+    return `http://localhost/${uuid()}`;
   } else {
     throw new TypeError('Failed to execute \'createObjectURL\' on \'URL\': No function was found that matched the signature provided.');
   }
 }
 
 export default createObjectURL;
-export { createObjectURLSpy };

--- a/test/App.test.js
+++ b/test/App.test.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import renderer from 'react-test-renderer';
 import App from '../src/App';
+import sinon from 'sinon';
+import { mount } from 'enzyme';
+import { mountToJson } from 'enzyme-to-json';
 import Deferred from './utils/Deferred';
 import NavigatorUserMediaError from './utils/NavigatorUserMediaError';
-
-import { MediaRecorderSpy } from './utils/MediaRecorder';
-import { createObjectURLSpy } from './utils/createObjectURL';
 
 describe('App', () => {
   let deferred;
@@ -14,38 +13,43 @@ describe('App', () => {
   beforeEach(() => {
     deferred = new Deferred();
     navigator.mediaDevices = { getUserMedia: constraints => deferred.promise };
-    component = renderer.create(<App />);
+    component = mount(<App />);
   });
 
-  it('renders null while loading', () => {
-    expect(component.toJSON()).toMatchSnapshot();
+  it('renders empty while loading', () => {
+    expect(mountToJson(component)).toMatchSnapshot();
   });
 
-  it('renders the video URL from the stream', async () => {
-    const stream = new MediaStream();
-    deferred.resolve(stream);
-
-    await deferred.promise;
-    expect(createObjectURLSpy).lastCalledWith(stream);
-    expect(component.toJSON()).toMatchSnapshot();
-  });
-
-  it('renders null when media access is denied', async () => {
+  it('renders empty when media access is denied', async () => {
     const error = new NavigatorUserMediaError();
     deferred.reject(error);
 
     try {
       await deferred.promise;
     } catch(e) {
-      expect(component.toJSON()).toMatchSnapshot();
+      expect(mountToJson(component)).toMatchSnapshot();
     }
   });
 
-  it('initializes the MediaRecorder', async () => {
+  it('renders the video URL from the stream', async () => {
+    const videoURL = 'http://localhost/e75dbc24-dd2c-4157-bf0e-f0a7773e98c8';
+    sinon.stub(URL, 'createObjectURL', stream => videoURL);
+
     const stream = new MediaStream();
     deferred.resolve(stream);
 
     await deferred.promise;
-    expect(MediaRecorderSpy).lastCalledWith(stream, { mimeType: 'video/webm;codecs=vp9' });
+    expect(URL.createObjectURL.calledWith(stream));
+    expect(mountToJson(component)).toMatchSnapshot();
+  });
+
+  it('initializes the MediaRecorder', async () => {
+    sinon.spy(global, 'MediaRecorder');
+
+    const stream = new MediaStream();
+    deferred.resolve(stream);
+
+    await deferred.promise;
+    expect(MediaRecorder.calledWith(stream, { mimeType: 'video/webm;codecs=vp9' }));
   });
 });

--- a/test/__snapshots__/App.test.js.snap
+++ b/test/__snapshots__/App.test.js.snap
@@ -1,12 +1,14 @@
-exports[`App renders null when media access is denied 1`] = `null`;
+exports[`App renders empty when media access is denied 1`] = `<App />`;
 
-exports[`App renders null while loading 1`] = `null`;
+exports[`App renders empty while loading 1`] = `<App />`;
 
 exports[`App renders the video URL from the stream 1`] = `
-<video
-  autoPlay={true}
-  className="fullscreen-video"
-  loop={true}
-  muted={true}
-  src="http://localhost/e75dbc24-dd2c-4157-bf0e-f0a7773e98c8" />
+<App>
+  <video
+    autoPlay={true}
+    className="fullscreen-video"
+    loop={true}
+    muted={true}
+    src="http://localhost/e75dbc24-dd2c-4157-bf0e-f0a7773e98c8" />
+</App>
 `;


### PR DESCRIPTION
- [enzyme](https://github.com/airbnb/enzyme) gives a better API to interact with the rendered components
- [sinon](http://sinonjs.org/) allows to spy without the complexity of jest or exporting
the spies from the modules which was more like a hack on my side https://github.com/gotik/reccam.io/pull/14/files#diff-fe33ea04c76a8b886d674c899c70d8b9L15 and https://github.com/gotik/reccam.io/pull/14/files#diff-d58a3b7919c5b840356557d7d9ec5338L19 😂 