### PR TITLE
Prevent zooming

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <title>RecCam</title>
   </head>


### PR DESCRIPTION
- We do not support camera zoom, the zoom we are removing
is an HTML zoom that zooms the entire page